### PR TITLE
Fix for https://nvd.nist.gov/vuln/detail/CVE-2021-27568

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,8 +39,8 @@ object Dependencies {
 
     val argon2 = "de.mkammerer" % "argon2-jvm" % "2.11"
     val jbcrypt = "de.svenkubiak" % "jBCrypt" % "0.4.1"
-    val jwtCore = "com.atlassian.jwt" % "jwt-core" % "2.1.0"
-    val jwtApi = "com.atlassian.jwt" % "jwt-api" % "2.1.0"
+    val jwtCore = "com.atlassian.jwt" % "jwt-core" % "3.2.3"
+    val jwtApi = "com.atlassian.jwt" % "jwt-api" % "3.2.3" % "provided"
     val scalaGuice = "net.codingwell" %% "scala-guice" % "4.2.5"
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % play.core.PlayVersion.akkaVersion
     val casClient = "org.jasig.cas.client" % "cas-client-core" % "3.4.1"


### PR DESCRIPTION
old version of atlasian jwt contains json-smart issue which is critical issue due to https://ossindex.sonatype.org/vulnerability/2f4d58e2-444b-4231-bec2-2a2c2135b9d7?component-type=maven&component-name=net.minidev.json-smart&utm_source=dependency-check&utm_medium=integration&utm_content=6.1.0

License for new libs is Apache 2.0

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you suggest documentation edits?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

Security fix

## Background Context

This issue is critical

## References

Are there any relevant issues / PRs / mailing lists discussions?
