### PR TITLE
Fixed LinkedInProfileParser throwing error when user has no image set.

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/oauth2/LinkedInProvider.scala
@@ -80,7 +80,7 @@ trait BaseLinkedInProvider extends OAuth2Provider {
   override protected def buildProfile(authInfo: OAuth2Info): Future[Profile] = {
     Future.sequence(Seq(getPartialProfile(urls("api"), authInfo), getPartialProfile(urls("email"), authInfo), getPartialProfile(urls("photo"), authInfo))).flatMap {
       partial =>
-        val array: JsValue = JsObject(Seq("api" -> partial(0), "email" -> partial(1), "photo" -> partial(2)))
+        val array: JsValue = JsObject(Seq("api" -> partial.head, "email" -> partial(1), "photo" -> partial(2)))
         profileParser.parse(array, authInfo)
     }
   }
@@ -103,8 +103,8 @@ class LinkedInProfileParser extends SocialProfileParser[JsValue, CommonSocialPro
     val firstName = (json \ "api" \ "localizedFirstName").asOpt[String]
     val lastName = (json \ "api" \ "localizedLastName").asOpt[String]
     val fullName = Some(firstName.getOrElse("") + " " + lastName.getOrElse("")).map(_.trim)
-    val avatarURL = (json \\ "identifier")(0).asOpt[String]
-    val email = (json \\ "emailAddress")(0).asOpt[String]
+    val avatarURL = (json \\ "identifier").headOption.map(_.as[String])
+    val email = (json \\ "emailAddress").headOption.map(_.as[String])
 
     CommonSocialProfile(
       loginInfo = LoginInfo(ID, userID),


### PR DESCRIPTION
# Pull Request Checklist

* [Y] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [Y] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette/blob/master/CONTRIBUTING.md)?
* [N] Have you added copyright headers to new files?
* [N] Have you suggest documentation edits?
* [N] Have you added tests for any changed functionality?

## Fixes

There is an error with LinkedIn OAuth2 parser. When user has no image set parser will throw index out of bounds exception. Instead of using (0).asOpt[String] I've used headOption nad as[String]. Simple fix.

## Purpose

It fixes obscure parser bug.

## Background Context

I had to fix this fast for our internal release, and I thought that it might be useful.

## References


