### PR TITLE
Remove joda time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,6 @@ lazy val silhouette = (project in file("silhouette"))
         Library.Play.cache,
         Library.Play.ws,
         Library.Play.openid,
-        Library.Play.jsonJoda,
         Library.jwtCore,
         Library.jwtApi,
         Library.apacheCommonLang,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,6 @@ object Dependencies {
       val test = "com.typesafe.play" %% "play-test" % version
       val specs2 = "com.typesafe.play" %% "play-specs2" % version
       val openid = "com.typesafe.play" %% "play-openid" % version
-      val jsonJoda = "com.typesafe.play" %% "play-json-joda" % "2.9.2"
     }
 
     object Specs2 {

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/api/Authenticator.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/api/Authenticator.scala
@@ -20,8 +20,8 @@
 package io.github.honeycombcheesecake.play.silhouette.api
 
 import io.github.honeycombcheesecake.play.silhouette.api.Authenticator.Implicits._
-import org.joda.time.DateTime
 
+import java.time.ZonedDateTime
 import scala.concurrent.duration.FiniteDuration
 
 /**
@@ -65,11 +65,11 @@ object Authenticator {
   object Implicits {
 
     /**
-     * Defines additional methods on an `DateTime` instance.
+     * Defines additional methods on a `ZonedDateTime` instance.
      *
-     * @param dateTime The `DateTime` instance on which the additional methods should be defined.
+     * @param dateTime The `ZonedDateTime` instance on which the additional methods should be defined.
      */
-    implicit class RichDateTime(dateTime: DateTime) {
+    implicit class RichDateTime(dateTime: ZonedDateTime) {
 
       /**
        * Adds a duration to a date/time.
@@ -77,7 +77,7 @@ object Authenticator {
        * @param duration The duration to add.
        * @return A date/time instance with the added duration.
        */
-      def +(duration: FiniteDuration): DateTime = {
+      def +(duration: FiniteDuration): ZonedDateTime = {
         dateTime.plusSeconds(duration.toSeconds.toInt)
       }
 
@@ -87,8 +87,17 @@ object Authenticator {
        * @param duration The duration to subtract.
        * @return A date/time instance with the subtracted duration.
        */
-      def -(duration: FiniteDuration): DateTime = {
+      def -(duration: FiniteDuration): ZonedDateTime = {
         dateTime.minusSeconds(duration.toSeconds.toInt)
+      }
+
+      /**
+       * Compares a date/time with the current time
+       *
+       * @return Is the current time before the time supplied by the Clock
+       */
+      def isBeforeNow: Boolean = {
+        dateTime.isBefore(ZonedDateTime.now)
       }
     }
   }
@@ -115,12 +124,12 @@ trait ExpirableAuthenticator extends Authenticator {
   /**
    * The last used date/time.
    */
-  val lastUsedDateTime: DateTime
+  val lastUsedDateTime: ZonedDateTime
 
   /**
    * The expiration date/time.
    */
-  val expirationDateTime: DateTime
+  val expirationDateTime: ZonedDateTime
 
   /**
    * The duration an authenticator can be idle before it timed out.

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/api/util/Clock.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/api/util/Clock.scala
@@ -15,19 +15,19 @@
  */
 package io.github.honeycombcheesecake.play.silhouette.api.util
 
-import org.joda.time.DateTime
+import java.time.{ Instant, ZonedDateTime, ZoneId, Clock => JavaClock }
 
 /**
- * A trait which provides a mockable implementation for a DateTime instance.
+ * A trait which provides a mockable implementation for a Clock instance.
  */
-trait Clock {
+trait Clock extends JavaClock {
 
   /**
    * Gets the current DateTime.
    *
    * @return the current DateTime.
    */
-  def now: DateTime
+  def now: ZonedDateTime
 }
 
 /**
@@ -40,7 +40,15 @@ object Clock {
    *
    * @return A Clock implementation.
    */
-  def apply() = new Clock {
-    def now = DateTime.now
+  def apply(): Clock = Clock(JavaClock.systemDefaultZone)
+
+  def apply(clock: JavaClock): Clock = new Clock {
+    def now: ZonedDateTime = ZonedDateTime.now(clock)
+
+    def getZone: ZoneId = clock.getZone
+
+    override def withZone(zone: ZoneId): Clock = Clock(clock.withZone(zone))
+
+    def instant(): Instant = clock.instant
   }
 }

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/BearerTokenAuthenticator.scala
@@ -23,9 +23,9 @@ import io.github.honeycombcheesecake.play.silhouette.api.services.{ Authenticato
 import io.github.honeycombcheesecake.play.silhouette.api.util._
 import io.github.honeycombcheesecake.play.silhouette.api.{ ExpirableAuthenticator, Logger, LoginInfo, StorableAuthenticator }
 import io.github.honeycombcheesecake.play.silhouette.impl.authenticators.BearerTokenAuthenticatorService._
-import org.joda.time.DateTime
 import play.api.mvc.{ RequestHeader, Result }
 
+import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
@@ -50,8 +50,8 @@ import scala.util.Try
 case class BearerTokenAuthenticator(
   id: String,
   loginInfo: LoginInfo,
-  lastUsedDateTime: DateTime,
-  expirationDateTime: DateTime,
+  lastUsedDateTime: ZonedDateTime,
+  expirationDateTime: ZonedDateTime,
   idleTimeout: Option[FiniteDuration])
   extends StorableAuthenticator with ExpirableAuthenticator {
 

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/CookieAuthenticator.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/CookieAuthenticator.scala
@@ -28,11 +28,11 @@ import io.github.honeycombcheesecake.play.silhouette.api.services.AuthenticatorS
 import io.github.honeycombcheesecake.play.silhouette.api.services.{ AuthenticatorResult, AuthenticatorService }
 import io.github.honeycombcheesecake.play.silhouette.api.util._
 import io.github.honeycombcheesecake.play.silhouette.impl.authenticators.CookieAuthenticatorService._
-import org.joda.time.DateTime
 import play.api.libs.json.{ Json, OFormat }
 import play.api.mvc._
 import play.api.mvc.request.{ Cell, RequestAttrKey }
 
+import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
@@ -65,8 +65,8 @@ import scala.util.{ Failure, Success, Try }
 case class CookieAuthenticator(
   id: String,
   loginInfo: LoginInfo,
-  lastUsedDateTime: DateTime,
-  expirationDateTime: DateTime,
+  lastUsedDateTime: ZonedDateTime,
+  expirationDateTime: ZonedDateTime,
   idleTimeout: Option[FiniteDuration],
   cookieMaxAge: Option[FiniteDuration],
   fingerprint: Option[String]) extends StorableAuthenticator with ExpirableAuthenticator {
@@ -82,8 +82,6 @@ case class CookieAuthenticator(
  */
 object CookieAuthenticator extends Logger {
   import io.github.honeycombcheesecake.play.silhouette.api.util.JsonFormats._
-  import play.api.libs.json.JodaReads._
-  import play.api.libs.json.JodaWrites._
 
   /**
    * Converts the CookieAuthenticator to Json and vice versa.

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/SessionAuthenticator.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/authenticators/SessionAuthenticator.scala
@@ -23,11 +23,11 @@ import io.github.honeycombcheesecake.play.silhouette.api.services.{ Authenticato
 import io.github.honeycombcheesecake.play.silhouette.api.util.{ Clock, ExtractableRequest, FingerprintGenerator }
 import io.github.honeycombcheesecake.play.silhouette.api.{ Authenticator, ExpirableAuthenticator, Logger, LoginInfo }
 import io.github.honeycombcheesecake.play.silhouette.impl.authenticators.SessionAuthenticatorService._
-import org.joda.time.DateTime
 import play.api.libs.json.{ Json, OFormat }
 import play.api.mvc._
 import play.api.mvc.request.{ Cell, RequestAttrKey }
 
+import java.time.ZonedDateTime
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
@@ -48,8 +48,8 @@ import scala.util.{ Failure, Success, Try }
  */
 case class SessionAuthenticator(
   loginInfo: LoginInfo,
-  lastUsedDateTime: DateTime,
-  expirationDateTime: DateTime,
+  lastUsedDateTime: ZonedDateTime,
+  expirationDateTime: ZonedDateTime,
   idleTimeout: Option[FiniteDuration],
   fingerprint: Option[String])
   extends Authenticator with ExpirableAuthenticator {
@@ -65,8 +65,6 @@ case class SessionAuthenticator(
  */
 object SessionAuthenticator extends Logger {
   import io.github.honeycombcheesecake.play.silhouette.api.util.JsonFormats._
-  import play.api.libs.json.JodaReads._
-  import play.api.libs.json.JodaWrites._
 
   /**
    * Converts the SessionAuthenticator to Json and vice versa.

--- a/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
+++ b/silhouette/app/io/github/honeycombcheesecake/play/silhouette/impl/providers/oauth1/secrets/CookieSecret.scala
@@ -16,14 +16,16 @@
 package io.github.honeycombcheesecake.play.silhouette.impl.providers.oauth1.secrets
 
 import javax.inject.Inject
+import io.github.honeycombcheesecake.play.silhouette.api.Authenticator.Implicits._
 import io.github.honeycombcheesecake.play.silhouette.api.crypto.{ Crypter, Signer }
 import io.github.honeycombcheesecake.play.silhouette.api.util.{ Clock, ExtractableRequest }
 import io.github.honeycombcheesecake.play.silhouette.impl.exceptions.OAuth1TokenSecretException
 import io.github.honeycombcheesecake.play.silhouette.impl.providers.oauth1.secrets.CookieSecretProvider._
 import io.github.honeycombcheesecake.play.silhouette.impl.providers.{ OAuth1Info, OAuth1TokenSecret, OAuth1TokenSecretProvider }
-import org.joda.time.DateTime
 import play.api.libs.json.{ Json, OFormat }
 import play.api.mvc.{ Cookie, Result }
+
+import java.time.ZonedDateTime
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -33,9 +35,6 @@ import scala.util.{ Failure, Success, Try }
  * The cookie secret companion object.
  */
 object CookieSecret {
-  import play.api.libs.json.JodaReads._
-  import play.api.libs.json.JodaWrites._
-
   /**
    * Converts the [[CookieSecret]]] to Json and vice versa.
    */
@@ -91,7 +90,7 @@ object CookieSecret {
  * @param value The token secret.
  * @param expirationDate The expiration time.
  */
-case class CookieSecret(value: String, expirationDate: DateTime) extends OAuth1TokenSecret {
+case class CookieSecret(value: String, expirationDate: ZonedDateTime) extends OAuth1TokenSecret {
 
   /**
    * Checks if the secret is expired. This is an absolute timeout since the creation of the secret.

--- a/silhouette/test/io/github/honeycombcheesecake/play/silhouette/api/AuthenticatorSpec.scala
+++ b/silhouette/test/io/github/honeycombcheesecake/play/silhouette/api/AuthenticatorSpec.scala
@@ -16,9 +16,9 @@
 package io.github.honeycombcheesecake.play.silhouette.api
 
 import io.github.honeycombcheesecake.play.silhouette.api.Authenticator.Implicits._
-import org.joda.time.DateTime
 import play.api.test.PlaySpecification
 
+import java.time.{ ZoneId, ZonedDateTime }
 import scala.concurrent.duration._
 
 /**
@@ -28,27 +28,27 @@ class AuthenticatorSpec extends PlaySpecification {
 
   "The + method of the RichDateTime class" should {
     "add a second to a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) + 1.second must be equalTo new DateTime(2015, 6, 16, 19, 46, 1)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) + 1.second must be equalTo ZonedDateTime.of(2015, 6, 16, 19, 46, 1, 0, ZoneId.systemDefault)
     }
 
     "add a minute to a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) + 1.minute must be equalTo new DateTime(2015, 6, 16, 19, 47, 0)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) + 1.minute must be equalTo ZonedDateTime.of(2015, 6, 16, 19, 47, 0, 0, ZoneId.systemDefault)
     }
 
     "add an hour to a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) + 1.hour must be equalTo new DateTime(2015, 6, 16, 20, 46, 0)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) + 1.hour must be equalTo ZonedDateTime.of(2015, 6, 16, 20, 46, 0, 0, ZoneId.systemDefault)
     }
 
     "subtract a second from a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) - 1.second must be equalTo new DateTime(2015, 6, 16, 19, 45, 59)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) - 1.second must be equalTo ZonedDateTime.of(2015, 6, 16, 19, 45, 59, 0, ZoneId.systemDefault)
     }
 
     "subtract a minute from a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) - 1.minute must be equalTo new DateTime(2015, 6, 16, 19, 45, 0)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) - 1.minute must be equalTo ZonedDateTime.of(2015, 6, 16, 19, 45, 0, 0, ZoneId.systemDefault)
     }
 
     "subtract an hour from a DateTime instance" in {
-      new DateTime(2015, 6, 16, 19, 46, 0) - 1.hour must be equalTo new DateTime(2015, 6, 16, 18, 46, 0)
+      ZonedDateTime.of(2015, 6, 16, 19, 46, 0, 0, ZoneId.systemDefault) - 1.hour must be equalTo ZonedDateTime.of(2015, 6, 16, 18, 46, 0, 0, ZoneId.systemDefault)
     }
   }
 }

--- a/silhouette/test/io/github/honeycombcheesecake/play/silhouette/api/util/ClockSpec.scala
+++ b/silhouette/test/io/github/honeycombcheesecake/play/silhouette/api/util/ClockSpec.scala
@@ -15,8 +15,9 @@
  */
 package io.github.honeycombcheesecake.play.silhouette.api.util
 
-import org.joda.time.DateTime
 import play.api.test._
+
+import java.time.ZonedDateTime
 
 /**
  * Test case for the [[io.github.honeycombcheesecake.play.silhouette.api.util.Clock]] class.
@@ -31,7 +32,7 @@ class ClockSpec extends PlaySpecification {
 
   "The `now` method" should {
     "return a new DateTime instance" in {
-      Clock().now should beAnInstanceOf[DateTime]
+      Clock().now should beAnInstanceOf[ZonedDateTime]
     }
   }
 }

--- a/silhouette/test/io/github/honeycombcheesecake/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
+++ b/silhouette/test/io/github/honeycombcheesecake/play/silhouette/impl/providers/oauth1/secrets/CookieSecretSpec.scala
@@ -23,7 +23,6 @@ import io.github.honeycombcheesecake.play.silhouette.impl.exceptions.OAuth1Token
 import io.github.honeycombcheesecake.play.silhouette.impl.providers.OAuth1Info
 import io.github.honeycombcheesecake.play.silhouette.impl.providers.oauth1.secrets.CookieSecret._
 import io.github.honeycombcheesecake.play.silhouette.impl.providers.oauth1.secrets.CookieSecretProvider._
-import org.joda.time.DateTime
 import org.specs2.control.NoLanguageFeatures
 import org.specs2.matcher.JsonMatchers
 import org.specs2.mock.Mockito
@@ -31,6 +30,7 @@ import org.specs2.specification.Scope
 import play.api.mvc.{ Cookie, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
 
+import java.time.{ ZoneId, ZonedDateTime }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -44,11 +44,11 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
 
   "The `isExpired` method of the secret" should {
     "return true if the secret is expired" in new Context {
-      secret.copy(expirationDate = DateTime.now.minusHours(1)).isExpired must beTrue
+      secret.copy(expirationDate = ZonedDateTime.now.minusHours(1)).isExpired must beTrue
     }
 
     "return false if the secret isn't expired" in new Context {
-      secret.copy(expirationDate = DateTime.now.plusHours(1)).isExpired must beFalse
+      secret.copy(expirationDate = ZonedDateTime.now.plusHours(1)).isExpired must beFalse
     }
   }
 
@@ -102,7 +102,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
   "The `build` method of the provider" should {
     "return a new secret" in new WithApplication with Context {
       implicit val req = FakeRequest()
-      val dateTime = new DateTime(2014, 8, 8, 0, 0, 0)
+      val dateTime = ZonedDateTime.of(2014, 8, 8, 0, 0, 0, 0, ZoneId.systemDefault)
 
       clock.now returns dateTime
 
@@ -123,7 +123,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
     }
 
     "throw an OAuth1TokenSecretException if secret is expired" in new WithApplication with Context {
-      val expiredSecret = secret.copy(expirationDate = DateTime.now.minusHours(1))
+      val expiredSecret = secret.copy(expirationDate = ZonedDateTime.now.minusHours(1))
 
       implicit val req = FakeRequest().withCookies(Cookie(settings.cookieName, CookieSecret.serialize(expiredSecret, signer, crypter)))
 
@@ -237,7 +237,7 @@ class CookieSecretSpec extends PlaySpecification with Mockito with JsonMatchers 
      * A secret to test.
      */
     lazy val secret = spy(new CookieSecret(
-      expirationDate = DateTime.now.plusSeconds(settings.expirationTime.toSeconds.toInt),
+      expirationDate = ZonedDateTime.now.plusSeconds(settings.expirationTime.toSeconds.toInt),
       value = "value"))
   }
 }

--- a/silhouette/test/io/github/honeycombcheesecake/play/silhouette/impl/util/PlayCacheLayerSpec.scala
+++ b/silhouette/test/io/github/honeycombcheesecake/play/silhouette/impl/util/PlayCacheLayerSpec.scala
@@ -15,12 +15,12 @@
  */
 package io.github.honeycombcheesecake.play.silhouette.impl.util
 
-import org.joda.time.DateTime
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.api.cache.AsyncCacheApi
 import play.api.test.PlaySpecification
 
+import java.time.ZonedDateTime
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
@@ -31,11 +31,11 @@ class PlayCacheLayerSpec extends PlaySpecification with Mockito {
 
   "The `find` method" should {
     "return value from cache" in new Context {
-      cacheAPI.get[DateTime]("id") returns Future.successful(Some(value))
+      cacheAPI.get[ZonedDateTime]("id") returns Future.successful(Some(value))
 
-      await(layer.find[DateTime]("id")) should beSome(value)
+      await(layer.find[ZonedDateTime]("id")) should beSome(value)
 
-      there was one(cacheAPI).get[DateTime]("id")
+      there was one(cacheAPI).get[ZonedDateTime]("id")
     }
   }
 
@@ -73,6 +73,6 @@ class PlayCacheLayerSpec extends PlaySpecification with Mockito {
     /**
      * The value to cache.
      */
-    lazy val value = new DateTime
+    lazy val value = ZonedDateTime.now
   }
 }


### PR DESCRIPTION
Removes the dependency on Joda Time.

This is a breaking change, as public facing APIs will now require JSR-310 `java.time.ZonedDateTime` values instead of `org.joda.time.DateTime` values.

A transitive dependency on Joda Time still remains, as the Play library currently depends on Play-Json v2.8.2, which still includes Joda time.  Resolving this is really in the hands of the Play team - they'll need to use Play-Json v2.9.x or later to eliminate this.

Pinning the Play-Json dependency to 2.9.2 would remove the Joda Time dependency... but with quite a lot of risk attached.  That's probably not worth it.  Further, the users of Play-Silhouette will all be depending directly on the Play framework themselves, so they'll _still_ end up with a dependency on Joda Time.